### PR TITLE
Methods for device selection

### DIFF
--- a/vcamera/pom.xml
+++ b/vcamera/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.vaadin.addons.parttio</groupId>
     <artifactId>vcamera</artifactId>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.1.0-SNAPSHOT</version>
     <name>Vcamera</name>
     <description>Integration of app-media for Vaadin 14+</description>
 
@@ -89,6 +89,12 @@
             <version>3.8.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.2</version>
+        </dependency>
+
 
     </dependencies>
 

--- a/vcamera/src/main/java/org/vaadin/vcamera/VCamera.java
+++ b/vcamera/src/main/java/org/vaadin/vcamera/VCamera.java
@@ -1,13 +1,22 @@
 package org.vaadin.vcamera;
 
 import java.io.OutputStream;
+import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.page.PendingJavaScriptResult;
 import com.vaadin.flow.server.StreamReceiver;
 import com.vaadin.flow.server.StreamVariable;
 import com.vaadin.flow.shared.Registration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.vaadin.vcamera.mediadevices.Device;
+import org.vaadin.vcamera.mediadevices.DevicesListedEvent;
 
 /**
  * A special video element that streams content from browser camera.
@@ -18,6 +27,8 @@ public class VCamera extends Component {
 
     private boolean cameraOn;
     private boolean recording;
+
+    private static final Logger LOG = LoggerFactory.getLogger(VCamera.class);
 
     public VCamera() {
         getElement().setProperty("volume", 0);
@@ -49,7 +60,7 @@ public class VCamera extends Component {
                     }).then(response => console.log(response));
                 }
                 this.recorder.start();
-                    """);
+                """);
     }
 
     public void stopRecording() {
@@ -110,8 +121,77 @@ public class VCamera extends Component {
                         });
                     }
                 }
-                        """.formatted(optionsJson));
+                """.formatted(optionsJson));
     }
+
+    /**
+     * Opens a specific videoinput device.
+     * @param device device to open
+     * @throws IllegalArgumentException if device is not of kind "videoinput"
+     */
+    public void openCamera(Device device) {
+        String sourceId = device.getDeviceId();
+        if(device.getKind() != Device.DeviceKind.videoinput) {
+            throw new IllegalArgumentException("Device "+device+" is not a video device");
+        }
+        openCamera("""
+                 {  video: {
+                      optional: [{sourceId: "%s"}]
+                 }}
+                 """.formatted(sourceId));
+    }
+
+    /**
+     * Reads available devices on the users browser
+     * @param listener is called with a list of devices after Javascript execution completes
+     */
+    public void listDevices(ComponentEventListener<DevicesListedEvent> listener) {
+        PendingJavaScriptResult pendingJavaScriptResult = getElement().executeJs("""
+                 if (!navigator.mediaDevices || !navigator.mediaDevices.enumerateDevices) {
+                   console.log("enumerateDevices() not supported.");
+                   return "";
+                 }
+                
+                 // List cameras and microphones
+                 return new Promise(function(myResolve, myReject){
+                    navigator.mediaDevices.enumerateDevices()
+                        .then(function(devices) {
+                            devicesString = JSON.stringify(devices);
+                            myResolve(devicesString); // when successful
+                            myReject("");  // when error
+                     } )
+                   });
+                """);
+
+        pendingJavaScriptResult.then(String.class, (s) -> {
+            ObjectMapper objectMapper = new ObjectMapper();
+            try {
+                List<Device> devices = objectMapper.readValue(s, new TypeReference<>() {
+                });
+                DevicesListedEvent event = new DevicesListedEvent(this, false, devices);
+                listener.onComponentEvent(event);
+            } catch (JsonProcessingException e) {
+                LOG.error("Could not read devices");
+                listener.onComponentEvent(new DevicesListedEvent(this, false, List.of()));
+            }
+        });
+    }
+
+    /**
+     * Tries to open the "normal", back-facing camera on a mobile phone. While it is possible to set a constraint facingMode = environment,
+     * it is up to the device, which camera to use. E.g. there could be a fishEye camera which is then used, which is rarely wanted.
+     * <a href="https://www.reddit.com/r/javascript/comments/8eg8w5/comment/dxvqycs/">A reddit post</a> mentions, that the most reliable way
+     * was to just use the last enumerated device as returned by {@link #listDevices(ComponentEventListener)}
+     */
+    public void openNormalEnvironmentCamera() {
+        listDevices(e -> {
+            List<Device> videoDevices = e.getDevices().stream()
+                    .filter(device -> device.getKind() == Device.DeviceKind.videoinput)
+                    .toList();
+            openCamera(videoDevices.get(videoDevices.size() - 1));
+        });
+    }
+
 
     public boolean isCameraOpen() {
         return cameraOn;

--- a/vcamera/src/main/java/org/vaadin/vcamera/VCamera.java
+++ b/vcamera/src/main/java/org/vaadin/vcamera/VCamera.java
@@ -27,6 +27,7 @@ public class VCamera extends Component {
 
     private boolean cameraOn;
     private boolean recording;
+    private boolean flashOn;
 
     private static final Logger LOG = LoggerFactory.getLogger(VCamera.class);
 
@@ -122,6 +123,27 @@ public class VCamera extends Component {
                     }
                 }
                 """.formatted(optionsJson));
+    }
+
+    public boolean isFlashOn() {
+        return flashOn;
+    }
+
+    public void toggleFlashlight() {
+        flashOn = !flashOn;
+        getElement().executeJs("""
+                if(this.stream != null) {
+                    const track = this.stream.getVideoTracks()[0];
+            
+                    //Create image capture object and get camera capabilities
+                    const imageCapture = new ImageCapture(track)
+                    const photoCapabilities = imageCapture.getPhotoCapabilities().then(() => {
+                      track.applyConstraints({
+                        advanced: [{torch: %s}]
+                      });
+                    });
+                }
+            """.formatted(flashOn));
     }
 
     /**

--- a/vcamera/src/main/java/org/vaadin/vcamera/VCamera.java
+++ b/vcamera/src/main/java/org/vaadin/vcamera/VCamera.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.page.PendingJavaScriptResult;
 import com.vaadin.flow.server.StreamReceiver;
@@ -23,7 +24,7 @@ import org.vaadin.vcamera.mediadevices.DevicesListedEvent;
  * <p>During streaming, users can record still or video clips of the stream, that browser send to the server. The data can be accessed using the DataReceiver interface, see {@link #setReceiver(DataReceiver)}.</p>
  */
 @Tag("video")
-public class VCamera extends Component {
+public class VCamera extends Component implements HasSize {
 
     private boolean cameraOn;
     private boolean recording;

--- a/vcamera/src/main/java/org/vaadin/vcamera/mediadevices/Device.java
+++ b/vcamera/src/main/java/org/vaadin/vcamera/mediadevices/Device.java
@@ -1,0 +1,56 @@
+package org.vaadin.vcamera.mediadevices;
+
+/**
+ * A device as returned by Javascripts MediaDevices: enumerateDevices
+ */
+public class Device {
+
+    public enum DeviceKind {
+        videoinput, audioinput, audiooutput
+    }
+
+    private String deviceId, label, groupId;
+    private DeviceKind kind;
+
+    public DeviceKind getKind() {
+        return kind;
+    }
+
+    public void setKind(DeviceKind kind) {
+        this.kind = kind;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public void setDeviceId(String deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    @Override
+    public String toString() {
+        return "Device{" +
+                "deviceId='" + deviceId + '\'' +
+                ", label='" + label + '\'' +
+                ", groupId='" + groupId + '\'' +
+                ", kind=" + kind +
+                '}';
+    }
+}

--- a/vcamera/src/main/java/org/vaadin/vcamera/mediadevices/DevicesListedEvent.java
+++ b/vcamera/src/main/java/org/vaadin/vcamera/mediadevices/DevicesListedEvent.java
@@ -1,0 +1,20 @@
+package org.vaadin.vcamera.mediadevices;
+
+import com.vaadin.flow.component.ComponentEvent;
+import org.vaadin.vcamera.VCamera;
+
+import java.util.List;
+
+public class DevicesListedEvent extends ComponentEvent<VCamera> {
+
+    private final List<Device> devices;
+
+    public DevicesListedEvent(VCamera source, boolean fromClient, List<Device> devices) {
+        super(source, fromClient);
+        this.devices = devices;
+    }
+
+    public List<Device> getDevices() {
+        return devices;
+    }
+}


### PR DESCRIPTION
Added methods to enumerate the clients devices, to open a specific device and to open the "normal" environment camera

I am writing an application where I want to scan barcodes. On my phone though, openCamera() opens the user-facing camera by default. 
When supplying an options string to OpenCamera with facingMode: { exact: "environment" }, my rear camera is openend, but with  a fish-eye lens.
A reddit comment https://www.reddit.com/r/javascript/comments/8eg8w5/comment/dxvqycs/ mentions, that the most reliable way to open the regular back facing camera, was to just use the last device as returned by enumerate devices, so I also added a method for that.
You may not want to include _openNormalEnvironmentCamera_ but I think _listDevices_ and _openCamera(Device device)_ at least are useful additions
